### PR TITLE
Replace fzaninotto/faker with fakerphp/faker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Generate random blog article titles and content (including markdown) using faker",
     "keywords": ["faker", "fixtures", "data", "blog", "news", "article"],
     "require": {
-        "fzaninotto/faker": "~1.4",
+        "fakerphp/faker": "^1.9.1",
         "php": ">=5.4.0"
     },
     "require-dev": {


### PR DESCRIPTION
This PR is replacing the dependency on deprecated `fzaninotto/faker` with the community maintained `fakerphp/faker` package.

See #2 for more details!

I haven't gotten the tests to run locally because of PHP versions, so I'm creating this PR in an attempt to trigger Travis builds.
I'm expecting to edit the Travis config along the way if tests doesn't pass.